### PR TITLE
Add support for authentication using an apikey of an OAuth service

### DIFF
--- a/client/auth/apikey/apikey_suite_test.go
+++ b/client/auth/apikey/apikey_suite_test.go
@@ -1,0 +1,13 @@
+package apikey_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API Key Auth Suite")
+}

--- a/client/auth/apikey/client.go
+++ b/client/auth/apikey/client.go
@@ -1,0 +1,23 @@
+package apikey
+
+import "net/http"
+
+const APIKeyHeader = "x-api-key"
+
+// This client is used for authentication using OAuth e.g. GitHub/GitHub Enterprise
+type RazeeApiKeyAuthClient struct {
+	apiKey string
+}
+
+func (r *RazeeApiKeyAuthClient) Authenticate(request *http.Request) error {
+	request.Header.Add(APIKeyHeader, r.apiKey)
+	return nil
+}
+
+func NewClient(apiKey string) (*RazeeApiKeyAuthClient, error) {
+	client := &RazeeApiKeyAuthClient{
+		apiKey: apiKey,
+	}
+
+	return client, nil
+}

--- a/client/auth/apikey/client_test.go
+++ b/client/auth/apikey/client_test.go
@@ -1,0 +1,37 @@
+package apikey_test
+
+import (
+	"github.com/IBM/satcon-client-go/client/auth/apikey"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"net/http"
+)
+
+var _ = Describe("Client", func() {
+
+	var apiKey string
+	BeforeEach(func() {
+		apiKey = "some_key"
+	})
+
+	It("returns a NewRazeeApiKeyClient", func() {
+		local, err := apikey.NewClient(apiKey)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(local).NotTo(BeNil())
+	})
+
+	Describe("ApiKeyClient testing", func() {
+		It("executes token retrieval", func() {
+			client, err := apikey.NewClient(apiKey)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+			request := http.Request{
+				Header: http.Header{},
+			}
+			request.Header.Add("content-type", "application/json")
+			err = client.Authenticate(&request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(request.Header.Get(apikey.APIKeyHeader)).To(Equal(apiKey))
+		})
+	})
+})


### PR DESCRIPTION
This is adding authentication using the `x-api-key` header. It's used in the examples of razee.io when configuring Razee with OAuth of GitHub or GitHub Enterprise.