### PR TITLE
Extend groups to have an array of clusters as a field

### DIFF
--- a/client/actions/clusters/cluster_client.go
+++ b/client/actions/clusters/cluster_client.go
@@ -14,14 +14,14 @@ import (
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 . ClusterService
 type ClusterService interface {
 	// RegisterCluster registers a new cluster under the specified organization ID.
-	RegisterCluster(string, types.Registration) (*RegisterClusterResponseDataDetails, error)
+	RegisterCluster(orgID string, registration types.Registration) (*RegisterClusterResponseDataDetails, error)
 	// ClustersByOrgID lists the clusters registered under the specified organization.
-	ClustersByOrgID(string) (types.ClusterList, error)
+	ClustersByOrgID(orgID string) (types.ClusterList, error)
 	// ClusterByName returns the cluster registered under the specified organization and name.
-	ClusterByName(string, string) (*types.Cluster, error)
+	ClusterByName(orgID string, clusterName string) (*types.Cluster, error)
 	// DeleteClusterByClusterID deletes the specified cluster from the specified org,
 	// including all resources under that cluster.
-	DeleteClusterByClusterID(string, string) (*DeleteClustersResponseDataDetails, error)
+	DeleteClusterByClusterID(orgID string, clusterID string) (*DeleteClustersResponseDataDetails, error)
 }
 
 // Client is an implementation of a satcon client.

--- a/client/actions/groups/group_by_name.go
+++ b/client/actions/groups/group_by_name.go
@@ -33,6 +33,7 @@ func NewGroupByNameVariables(orgID string, name string) GroupByNameVariables {
 		"orgId",
 		"name",
 		"created",
+		"clusters{id,orgId,clusterId,name,metadata}",
 	}
 
 	return vars

--- a/client/actions/groups/group_by_name_test.go
+++ b/client/actions/groups/group_by_name_test.go
@@ -45,6 +45,7 @@ var _ = Describe("GroupByName", func() {
 				"orgId",
 				"name",
 				"created",
+				"clusters{id,orgId,clusterId,name,metadata}",
 			))
 		})
 	})
@@ -64,6 +65,14 @@ var _ = Describe("GroupByName", func() {
 						UUID:  "asdf",
 						OrgID: orgID,
 						Name:  "group1",
+						Clusters: []types.Cluster{
+							{
+								ID:        "cid",
+								OrgID:     "oid",
+								ClusterID: "cid",
+								Name:      "cluster1",
+							},
+						},
 					},
 				},
 			}

--- a/client/actions/groups/groups.go
+++ b/client/actions/groups/groups.go
@@ -30,6 +30,7 @@ func NewGroupsVariables(orgID string) GroupsVariables {
 		"orgId",
 		"name",
 		"created",
+		"clusters{id,orgId,clusterId,name,metadata}",
 	}
 
 	return vars

--- a/client/actions/groups/groups_test.go
+++ b/client/actions/groups/groups_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Groups", func() {
 				"orgId",
 				"name",
 				"created",
+				"clusters{id,orgId,clusterId,name,metadata}",
 			))
 		})
 	})
@@ -61,6 +62,14 @@ var _ = Describe("Groups", func() {
 							UUID:  "asdf",
 							OrgID: orgID,
 							Name:  "cluster1",
+							Clusters: []types.Cluster{
+								{
+									ID:        "cid",
+									OrgID:     "oid",
+									ClusterID: "cid",
+									Name:      "cluster1",
+								},
+							},
 						},
 						{
 							UUID:  "qwer",

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -114,11 +114,12 @@ type RequestErrorDetails struct {
 type GroupList []Group
 
 type Group struct {
-	UUID    string    `json:"uuid,omitempty"`
-	OrgID   string    `json:"orgId,omitempty"`
-	Name    string    `json:"name,omitempty"`
-	Owner   BasicUser `json:"owner,omitempty"`
-	Created string    `json:"created,omitempty"`
+	UUID     string    `json:"uuid,omitempty"`
+	OrgID    string    `json:"orgId,omitempty"`
+	Name     string    `json:"name,omitempty"`
+	Owner    BasicUser `json:"owner,omitempty"`
+	Created  string    `json:"created,omitempty"`
+	Clusters []Cluster `json:"clusters,omitempty"`
 }
 
 // Registration is the encapsulation of the JSON registration body, which at this

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -71,29 +71,6 @@ var _ = Describe("Groups", func() {
 			}
 			Expect(found).To(BeTrue())
 
-			// create new cluster
-			newClusterDetails, err := c.Clusters.RegisterCluster(testConfig.OrgID, types.Registration{Name: clusterName})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(newClusterDetails).NotTo(BeNil())
-
-			// add new cluster to the group
-			_, err = c.Groups.GroupClusters(testConfig.OrgID, newGroupDetails.UUID, []string{newClusterDetails.ClusterID})
-			Expect(err).NotTo(HaveOccurred())
-
-			// get group by name and verify that the new cluster is part of it
-			group1, err := c.Groups.GroupByName(testConfig.OrgID, groupName1)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(group1).NotTo(BeNil())
-			Expect(group1.Name).To(Equal(groupName1))
-			Expect(group1.Clusters).To(HaveLen(1))
-			Expect(group1.Clusters[0].ClusterID).To(Equal(newClusterDetails.ClusterID))
-			Expect(group1.Clusters[0].Name).To(Equal(clusterName))
-
-			// delete cluster
-			delClusterDetails, err := c.Clusters.DeleteClusterByClusterID(testConfig.OrgID, newClusterDetails.ClusterID)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(delClusterDetails.DeletedClusterCount).To(Equal(1))
-
 			// delete the group using RemoveGroupByName
 			removeGroup1, err := c.Groups.RemoveGroupByName(testConfig.OrgID, groupName1)
 			Expect(err).NotTo(HaveOccurred())
@@ -152,6 +129,68 @@ var _ = Describe("Groups", func() {
 				}
 			}
 			Expect(found).To(BeFalse())
+		})
+
+		It("Assign group and check if servers are listed", func() {
+			// List the groups to check that group does not exist
+			groups, err := c.Groups.Groups(testConfig.OrgID)
+			Expect(err).NotTo(HaveOccurred())
+			found := false
+			for _, group := range groups {
+				if strings.Compare(group.Name, groupName1) == 0 {
+					found = true
+				}
+			}
+			Expect(found).To(BeFalse())
+
+			// create a new group
+			newGroupDetails, err := c.Groups.AddGroup(testConfig.OrgID, groupName1)
+			Expect(newGroupDetails.UUID).NotTo(BeEmpty())
+			Expect(err).NotTo(HaveOccurred())
+
+			// create new cluster
+			newClusterDetails, err := c.Clusters.RegisterCluster(testConfig.OrgID, types.Registration{Name: clusterName})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newClusterDetails).NotTo(BeNil())
+
+			// add new cluster to the group
+			_, err = c.Groups.GroupClusters(testConfig.OrgID, newGroupDetails.UUID, []string{newClusterDetails.ClusterID})
+			Expect(err).NotTo(HaveOccurred())
+
+			// get group by name and verify that the new cluster is part of it
+			group1, err := c.Groups.GroupByName(testConfig.OrgID, groupName1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(group1).NotTo(BeNil())
+			Expect(group1.Name).To(Equal(groupName1))
+			Expect(group1.Clusters).To(HaveLen(1))
+			Expect(group1.Clusters[0].ClusterID).To(Equal(newClusterDetails.ClusterID))
+			Expect(group1.Clusters[0].Name).To(Equal(clusterName))
+
+			// delete cluster
+			delClusterDetails, err := c.Clusters.DeleteClusterByClusterID(testConfig.OrgID, newClusterDetails.ClusterID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(delClusterDetails.DeletedClusterCount).To(Equal(1))
+
+			// delete the group using RemoveGroupByName
+			removeGroup1, err := c.Groups.RemoveGroupByName(testConfig.OrgID, groupName1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(removeGroup1.UUID).To(MatchRegexp(newGroupDetails.UUID))
+
+			// list groups again and prove group is gone
+			groups, err = c.Groups.Groups(testConfig.OrgID)
+			Expect(err).NotTo(HaveOccurred())
+			found = false
+			for _, group := range groups {
+				if strings.Compare(group.Name, groupName1) == 0 {
+					found = true
+				}
+			}
+			Expect(found).To(BeFalse())
+
+			// get group by name and verify that it does not exist
+			group1, err = c.Groups.GroupByName(testConfig.OrgID, groupName1)
+			Expect(err).To(HaveOccurred())
+			Expect(group1).To(BeNil())
 		})
 
 	})


### PR DESCRIPTION
This PR will add a field `Clusters` to the `Group` struct so that it will contain information about what clusters are bundled together in a group.

I extended the unit and integration tests to include this scenario.