### PR TITLE
CLOSES #35 Quoting issue

### DIFF
--- a/client/actions/channels/add_channel.go
+++ b/client/actions/channels/add_channel.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryAddChannel       = "addChannel"
-	AddChannelVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","name":"{{js .Name}}"{{end}}`
+	AddChannelVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
 )
 
 // AddChannelVariables are the variables specific to adding a group.

--- a/client/actions/channels/add_channel.go
+++ b/client/actions/channels/add_channel.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryAddChannel       = "addChannel"
-	AddChannelVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
+	AddChannelVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"name":{{json .Name}}{{end}}`
 )
 
 // AddChannelVariables are the variables specific to adding a group.

--- a/client/actions/channels/channel.go
+++ b/client/actions/channels/channel.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryChannel       = "channel"
-	ChannelVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","uuid":"{{js .UUID}}"{{end}}`
+	ChannelVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
 )
 
 // ChannelVariables to query channel

--- a/client/actions/channels/channel.go
+++ b/client/actions/channels/channel.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryChannel       = "channel"
-	ChannelVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
+	ChannelVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"uuid":{{json .UUID}}{{end}}`
 )
 
 // ChannelVariables to query channel

--- a/client/actions/channels/channel_by_name.go
+++ b/client/actions/channels/channel_by_name.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryChannelByName       = "channelByName"
-	ChannelByNameVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","name":"{{js .Name}}"{{end}}`
+	ChannelByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
 )
 
 // ChannelByNameVariables to query channel by name

--- a/client/actions/channels/channel_by_name.go
+++ b/client/actions/channels/channel_by_name.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryChannelByName       = "channelByName"
-	ChannelByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
+	ChannelByNameVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"name":{{json .Name}}{{end}}`
 )
 
 // ChannelByNameVariables to query channel by name

--- a/client/actions/channels/channels.go
+++ b/client/actions/channels/channels.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryChannels       = "channels"
-	ChannelsVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}"{{end}}`
+	ChannelsVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
 )
 
 type ChannelsVariables struct {

--- a/client/actions/channels/channels.go
+++ b/client/actions/channels/channels.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryChannels       = "channels"
-	ChannelsVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
+	ChannelsVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}}{{end}}`
 )
 
 type ChannelsVariables struct {

--- a/client/actions/channels/remove_channel.go
+++ b/client/actions/channels/remove_channel.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryRemoveChannel       = "removeChannel"
-	RemoveChannelVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","uuid":"{{js .UUID}}"{{end}}`
+	RemoveChannelVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
 )
 
 // RemoveChannelVariables are the variables specific to adding a group.

--- a/client/actions/channels/remove_channel.go
+++ b/client/actions/channels/remove_channel.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryRemoveChannel       = "removeChannel"
-	RemoveChannelVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
+	RemoveChannelVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"uuid":{{json .UUID}}{{end}}`
 )
 
 // RemoveChannelVariables are the variables specific to adding a group.

--- a/client/actions/clusters/clusters_by_name.go
+++ b/client/actions/clusters/clusters_by_name.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryClusterByName       = "clusterByName"
-	ClusterByNameVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","clusterName":"{{js .ClusterName}}"{{end}}`
+	ClusterByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","clusterName":"{{json .ClusterName}}"{{end}}`
 )
 
 type ClusterByNameVariables struct {

--- a/client/actions/clusters/clusters_by_name.go
+++ b/client/actions/clusters/clusters_by_name.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryClusterByName       = "clusterByName"
-	ClusterByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","clusterName":"{{json .ClusterName}}"{{end}}`
+	ClusterByNameVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"clusterName":{{json .ClusterName}}{{end}}`
 )
 
 type ClusterByNameVariables struct {

--- a/client/actions/clusters/clusters_by_org_id.go
+++ b/client/actions/clusters/clusters_by_org_id.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryClustersByOrgID       = "clustersByOrgId"
-	ClustersByOrgIDVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}"{{end}}`
+	ClustersByOrgIDVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
 )
 
 type ClustersByOrgIDVariables struct {

--- a/client/actions/clusters/clusters_by_org_id.go
+++ b/client/actions/clusters/clusters_by_org_id.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryClustersByOrgID       = "clustersByOrgId"
-	ClustersByOrgIDVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
+	ClustersByOrgIDVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}}{{end}}`
 )
 
 type ClustersByOrgIDVariables struct {

--- a/client/actions/clusters/delete_cluster_by_cluster_id.go
+++ b/client/actions/clusters/delete_cluster_by_cluster_id.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryDeleteClusterByClusterID       = "deleteClusterByClusterId"
-	DeleteClusterByClusterIDVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","clusterId":"{{js .ClusterID}}"{{end}}`
+	DeleteClusterByClusterIDVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","clusterId":"{{json .ClusterID}}"{{end}}`
 )
 
 type DeleteClusterByClusterIDVariables struct {

--- a/client/actions/clusters/delete_cluster_by_cluster_id.go
+++ b/client/actions/clusters/delete_cluster_by_cluster_id.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryDeleteClusterByClusterID       = "deleteClusterByClusterId"
-	DeleteClusterByClusterIDVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","clusterId":"{{json .ClusterID}}"{{end}}`
+	DeleteClusterByClusterIDVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"clusterId":{{json .ClusterID}}{{end}}`
 )
 
 type DeleteClusterByClusterIDVariables struct {

--- a/client/actions/clusters/register_cluster.go
+++ b/client/actions/clusters/register_cluster.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	QueryRegisterCluster       = "registerCluster"
-	RegisterClusterVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","registration":{{printf "%s" .Registration}}{{end}}`
+	RegisterClusterVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","registration":{{printf "%s" .Registration}}{{end}}`
 )
 
 // RegisterClusterVariables are the variables specific to cluster registration.

--- a/client/actions/clusters/register_cluster.go
+++ b/client/actions/clusters/register_cluster.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	QueryRegisterCluster       = "registerCluster"
-	RegisterClusterVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","registration":{{printf "%s" .Registration}}{{end}}`
+	RegisterClusterVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"registration":{{printf "%s" .Registration}}{{end}}`
 )
 
 // RegisterClusterVariables are the variables specific to cluster registration.

--- a/client/actions/groups/add_group.go
+++ b/client/actions/groups/add_group.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryAddGroup       = "addGroup"
-	AddGroupVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
+	AddGroupVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"name":{{json .Name}}{{end}}`
 )
 
 // AddGroupVariables are the variables specific to adding a group.

--- a/client/actions/groups/add_group.go
+++ b/client/actions/groups/add_group.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryAddGroup       = "addGroup"
-	AddGroupVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","name":"{{js .Name}}"{{end}}`
+	AddGroupVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
 )
 
 // AddGroupVariables are the variables specific to adding a group.

--- a/client/actions/groups/group_by_name.go
+++ b/client/actions/groups/group_by_name.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryGroupByName       = "groupByName"
-	GroupByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
+	GroupByNameVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"name":{{json .Name}}{{end}}`
 )
 
 type GroupByNameVariables struct {

--- a/client/actions/groups/group_by_name.go
+++ b/client/actions/groups/group_by_name.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryGroupByName       = "groupByName"
-	GroupByNameVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","name":"{{js .Name}}"{{end}}`
+	GroupByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
 )
 
 type GroupByNameVariables struct {

--- a/client/actions/groups/group_clusters.go
+++ b/client/actions/groups/group_clusters.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryGroupClusters       = "groupClusters"
-	GroupClustersVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}","clusters":[{{range $i,$e := .Clusters}}{{if gt $i 0}},{{end}}"{{json $e}}"{{end}}]{{end}}`
+	GroupClustersVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"uuid":{{json .UUID}},"clusters":[{{range $i,$e := .Clusters}}{{if gt $i 0}},{{end}}{{json $e}}{{end}}]{{end}}`
 )
 
 // GroupClustersVariables are the variables specific to grouping clusters.

--- a/client/actions/groups/group_clusters.go
+++ b/client/actions/groups/group_clusters.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryGroupClusters       = "groupClusters"
-	GroupClustersVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","uuid":"{{js .UUID}}","clusters":[{{range $i,$e := .Clusters}}{{if gt $i 0}},{{end}}"{{js $e}}"{{end}}]{{end}}`
+	GroupClustersVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}","clusters":[{{range $i,$e := .Clusters}}{{if gt $i 0}},{{end}}"{{json $e}}"{{end}}]{{end}}`
 )
 
 // GroupClustersVariables are the variables specific to grouping clusters.

--- a/client/actions/groups/groups.go
+++ b/client/actions/groups/groups.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryGroups       = "groups"
-	GroupsVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
+	GroupsVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}}{{end}}`
 )
 
 type GroupsVariables struct {

--- a/client/actions/groups/groups.go
+++ b/client/actions/groups/groups.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryGroups       = "groups"
-	GroupsVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}"{{end}}`
+	GroupsVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
 )
 
 type GroupsVariables struct {

--- a/client/actions/groups/remove_group.go
+++ b/client/actions/groups/remove_group.go
@@ -4,7 +4,7 @@ import "github.com/IBM/satcon-client-go/client/actions"
 
 const (
 	QueryRemoveGroup       = "removeGroup"
-	RemoveGroupVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","uuid":"{{js .UUID}}"{{end}}`
+	RemoveGroupVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
 )
 
 // RemoveGroupVariables are the variables specific to removing a group by name.

--- a/client/actions/groups/remove_group.go
+++ b/client/actions/groups/remove_group.go
@@ -4,7 +4,7 @@ import "github.com/IBM/satcon-client-go/client/actions"
 
 const (
 	QueryRemoveGroup       = "removeGroup"
-	RemoveGroupVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
+	RemoveGroupVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"uuid":{{json .UUID}}{{end}}`
 )
 
 // RemoveGroupVariables are the variables specific to removing a group by name.

--- a/client/actions/groups/remove_group_by_name.go
+++ b/client/actions/groups/remove_group_by_name.go
@@ -4,7 +4,7 @@ import "github.com/IBM/satcon-client-go/client/actions"
 
 const (
 	QueryRemoveGroupByName       = "removeGroupByName"
-	RemoveGroupByNameVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","name":"{{js .Name}}"{{end}}`
+	RemoveGroupByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
 )
 
 // RemoveGroupByNameVariables are the variables specific to removing a group by name.

--- a/client/actions/groups/remove_group_by_name.go
+++ b/client/actions/groups/remove_group_by_name.go
@@ -4,7 +4,7 @@ import "github.com/IBM/satcon-client-go/client/actions"
 
 const (
 	QueryRemoveGroupByName       = "removeGroupByName"
-	RemoveGroupByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}"{{end}}`
+	RemoveGroupByNameVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"name":{{json .Name}}{{end}}`
 )
 
 // RemoveGroupByNameVariables are the variables specific to removing a group by name.

--- a/client/actions/query.go
+++ b/client/actions/query.go
@@ -62,18 +62,7 @@ func BuildArgVarsList(args map[string]string) string {
 
 func JsonMarshalToString(v interface{}) (string, error) {
 	bytes, err := json.Marshal(v)
-
-	// we don't want the starting and ending double quotes if this is a string, so leave off first and last chars
-	switch v.(type) {
-	case string:
-		untrimmed := string(bytes)
-		if len(untrimmed) < 2 {
-			return "", errors.New("json.Marshal returned invalid JSON string?!?")
-		}
-		return untrimmed[1 : len(untrimmed)-1], err
-	default:
-		return string(bytes), err
-	}
+	return string(bytes), err
 }
 
 //BuildRequest builds the request and it sets the headers

--- a/client/actions/query_test.go
+++ b/client/actions/query_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Query", func() {
 		)
 
 		BeforeEach(func() {
-			requestTemplate = `{{define "vars"}}"first":"{{json .First}}","last":"{{json .Last}}"{{end}}`
+			requestTemplate = `{{define "vars"}}"first":{{json .First}},"last":{{json .Last}}{{end}}`
 			vars = requestVars{
 				First: "Don",
 				Last:  "Quixote",
@@ -219,7 +219,7 @@ var _ = Describe("Query", func() {
 
 		Context("When additional helper functions are passed in", func() {
 			BeforeEach(func() {
-				requestTemplate = `{{define "vars"}}"first":"{{json (toUpper .First)}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"first":{{json (toUpper .First)}}{{end}}`
 				funcs = template.FuncMap{
 					"toUpper": strings.ToUpper,
 				}
@@ -236,7 +236,7 @@ var _ = Describe("Query", func() {
 
 		Context("When the variable template does not escape json for all variables", func() {
 			BeforeEach(func() {
-				requestTemplate = `{{define "vars"}}"first":"{{json .First}}","last":"{{.Last}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"first":{{json .First}},"last":"{{.Last}}"{{end}}`
 			})
 
 			It("Returns nil and an error", func() {
@@ -260,7 +260,7 @@ var _ = Describe("Query", func() {
 
 		Context("When the template references variables not part of the struct", func() {
 			BeforeEach(func() {
-				requestTemplate = `{{define "vars"}}"first":"{{json .Foo}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"first":{{json .Foo}}{{end}}`
 			})
 
 			It("Returns nil and an error", func() {

--- a/client/actions/query_test.go
+++ b/client/actions/query_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Query", func() {
 		)
 
 		BeforeEach(func() {
-			requestTemplate = `{{define "vars"}}"first":"{{js .First}}","last":"{{js .Last}}"{{end}}`
+			requestTemplate = `{{define "vars"}}"first":"{{json .First}}","last":"{{json .Last}}"{{end}}`
 			vars = requestVars{
 				First: "Don",
 				Last:  "Quixote",
@@ -219,7 +219,7 @@ var _ = Describe("Query", func() {
 
 		Context("When additional helper functions are passed in", func() {
 			BeforeEach(func() {
-				requestTemplate = `{{define "vars"}}"first":"{{js (toUpper .First)}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"first":"{{json (toUpper .First)}}"{{end}}`
 				funcs = template.FuncMap{
 					"toUpper": strings.ToUpper,
 				}
@@ -234,9 +234,9 @@ var _ = Describe("Query", func() {
 			})
 		})
 
-		Context("When the variable template does not escape js for all variables", func() {
+		Context("When the variable template does not escape json for all variables", func() {
 			BeforeEach(func() {
-				requestTemplate = `{{define "vars"}}"first":"{{js .First}}","last":"{{.Last}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"first":"{{json .First}}","last":"{{.Last}}"{{end}}`
 			})
 
 			It("Returns nil and an error", func() {
@@ -248,7 +248,7 @@ var _ = Describe("Query", func() {
 
 		Context("When the variable template is not valid", func() {
 			BeforeEach(func() {
-				requestTemplate = `{{define "vars"}}{{js .First}}`
+				requestTemplate = `{{define "vars"}}{{json .First}}`
 			})
 
 			It("Returns nil and an error", func() {
@@ -260,7 +260,7 @@ var _ = Describe("Query", func() {
 
 		Context("When the template references variables not part of the struct", func() {
 			BeforeEach(func() {
-				requestTemplate = `{{define "vars"}}"first":"{{js .Foo}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"first":"{{json .Foo}}"{{end}}`
 			})
 
 			It("Returns nil and an error", func() {

--- a/client/actions/query_test.go
+++ b/client/actions/query_test.go
@@ -30,6 +30,34 @@ var _ = Describe("Query", func() {
 		}
 	})
 
+	Describe("json template function", func() {
+		type Special struct {
+			A string
+			B string
+			C string
+		}
+
+		FIt("Correctly escapes special characters", func() {
+			testSpecial := Special{
+					A: `'apostrophes'`,
+					B:  `"quotes"`,
+					C:  `\backslashes\`,
+			}
+			funcs := template.FuncMap{
+				"json": JsonMarshalToString,
+			}
+
+			tmpl, err := template.New("test").Funcs(funcs).Parse("{{json .A}} {{json .B}} {{json .C}}")
+			Expect(err).NotTo(HaveOccurred())
+
+			buf := &bytes.Buffer{}
+			err = tmpl.Execute(buf, testSpecial)
+			Expect(err).NotTo(HaveOccurred())
+			finalBytes, err := ioutil.ReadAll(buf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(finalBytes).To(Equal([]byte(`"'apostrophes'" "\"quotes\"" "\\backslashes\\"`)))
+		})
+	})
 	Describe("BuildArgsList", func() {
 		It("Returns a string containing a list delimited by ', '", func() {
 			argList := BuildArgsList(argMap)

--- a/client/actions/resources/resource_content.go
+++ b/client/actions/resources/resource_content.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryResourceContent       = "resourceContent"
-	ResourceContentVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}", "clusterId":"{{json .ClusterID}}", "resourceSelfLink":"{{json .ResourceSelfLink}}"{{end}}`
+	ResourceContentVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}}, "clusterId":{{json .ClusterID}}, "resourceSelfLink":{{json .ResourceSelfLink}}{{end}}`
 )
 
 // ResourceContentVariables variable to query resources for specified cluster

--- a/client/actions/resources/resource_content.go
+++ b/client/actions/resources/resource_content.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryResourceContent       = "resourceContent"
-	ResourceContentVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}", "clusterId":"{{js .ClusterID}}", "resourceSelfLink":"{{js .ResourceSelfLink}}"{{end}}`
+	ResourceContentVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}", "clusterId":"{{json .ClusterID}}", "resourceSelfLink":"{{json .ResourceSelfLink}}"{{end}}`
 )
 
 // ResourceContentVariables variable to query resources for specified cluster

--- a/client/actions/resources/resources.go
+++ b/client/actions/resources/resources.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryResources       = "resources"
-	ResourcesVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
+	ResourcesVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}}{{end}}`
 )
 
 // ResourcesVariables variable to query resources for specified cluster

--- a/client/actions/resources/resources.go
+++ b/client/actions/resources/resources.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryResources       = "resources"
-	ResourcesVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}"{{end}}`
+	ResourcesVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
 )
 
 // ResourcesVariables variable to query resources for specified cluster

--- a/client/actions/resources/resources_by_cluster.go
+++ b/client/actions/resources/resources_by_cluster.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryResourcesByCluster       = "resourcesByCluster"
-	ResourcesByClusterVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","clusterId":"{{js .ClusterID}}", "filter":"{{js .Filter}}","limit":{{js .Limit}}{{end}}`
+	ResourcesByClusterVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","clusterId":"{{json .ClusterID}}", "filter":"{{json .Filter}}","limit":{{json .Limit}}{{end}}`
 )
 
 // ResourcesByClusterVariables variable to query resources for specified cluster

--- a/client/actions/resources/resources_by_cluster.go
+++ b/client/actions/resources/resources_by_cluster.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	QueryResourcesByCluster       = "resourcesByCluster"
-	ResourcesByClusterVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","clusterId":"{{json .ClusterID}}", "filter":"{{json .Filter}}","limit":{{json .Limit}}{{end}}`
+	ResourcesByClusterVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"clusterId":{{json .ClusterID}}, "filter":{{json .Filter}},"limit":{{json .Limit}}{{end}}`
 )
 
 // ResourcesByClusterVariables variable to query resources for specified cluster

--- a/client/actions/subscriptions/add_subscription.go
+++ b/client/actions/subscriptions/add_subscription.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryAddSubscription       = "addSubscription"
-	AddSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}","groups":[{{range $i,$e := .Groups}}{{if gt $i 0}},{{end}}"{{json $e}}"{{end}}],"channelUuid":"{{json .ChannelUUID}}","versionUuid":"{{json .VersionUUID}}"{{end}}`
+	AddSubscriptionVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"name":{{json .Name}},"groups":[{{range $i,$e := .Groups}}{{if gt $i 0}},{{end}}{{json $e}}{{end}}],"channelUuid":{{json .ChannelUUID}},"versionUuid":{{json .VersionUUID}}{{end}}`
 )
 
 type AddSubscriptionVariables struct {

--- a/client/actions/subscriptions/add_subscription.go
+++ b/client/actions/subscriptions/add_subscription.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryAddSubscription       = "addSubscription"
-	AddSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","name":"{{js .Name}}","groups":[{{range $i,$e := .Groups}}{{if gt $i 0}},{{end}}"{{js $e}}"{{end}}],"channelUuid":"{{js .ChannelUUID}}","versionUuid":"{{js .VersionUUID}}"{{end}}`
+	AddSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","name":"{{json .Name}}","groups":[{{range $i,$e := .Groups}}{{if gt $i 0}},{{end}}"{{json $e}}"{{end}}],"channelUuid":"{{json .ChannelUUID}}","versionUuid":"{{json .VersionUUID}}"{{end}}`
 )
 
 type AddSubscriptionVariables struct {

--- a/client/actions/subscriptions/remove_subscription.go
+++ b/client/actions/subscriptions/remove_subscription.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryRemoveSubscription       = "removeSubscription"
-	RemoveSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
+	RemoveSubscriptionVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"uuid":{{json .UUID}}{{end}}`
 )
 
 // RemoveSubscriptionVariables are the variables specific to adding a group.

--- a/client/actions/subscriptions/remove_subscription.go
+++ b/client/actions/subscriptions/remove_subscription.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryRemoveSubscription       = "removeSubscription"
-	RemoveSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","uuid":"{{js .UUID}}"{{end}}`
+	RemoveSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
 )
 
 // RemoveSubscriptionVariables are the variables specific to adding a group.

--- a/client/actions/subscriptions/set_subscription.go
+++ b/client/actions/subscriptions/set_subscription.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QuerySetSubscription       = "setSubscription"
-	SetSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}","versionUuid":"{{json .VersionUUID}}"{{end}}`
+	SetSubscriptionVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"uuid":{{json .UUID}},"versionUuid":{{json .VersionUUID}}{{end}}`
 )
 
 type SetSubscriptionVariables struct {

--- a/client/actions/subscriptions/set_subscription.go
+++ b/client/actions/subscriptions/set_subscription.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QuerySetSubscription       = "setSubscription"
-	SetSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","uuid":"{{js .UUID}}","versionUuid":"{{js .VersionUUID}}"{{end}}`
+	SetSubscriptionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}","versionUuid":"{{json .VersionUUID}}"{{end}}`
 )
 
 type SetSubscriptionVariables struct {

--- a/client/actions/subscriptions/subscriptions.go
+++ b/client/actions/subscriptions/subscriptions.go
@@ -9,7 +9,7 @@ const (
 	//QuerySubscriptions specifies the query
 	QuerySubscriptions = "subscriptions"
 	//SubscriptionsVarTemplate is the template used to create the graphql query
-	SubscriptionsVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}"{{end}}`
+	SubscriptionsVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
 )
 
 //SubscriptionsVariables are the variables used for the subscription query

--- a/client/actions/subscriptions/subscriptions.go
+++ b/client/actions/subscriptions/subscriptions.go
@@ -9,7 +9,7 @@ const (
 	//QuerySubscriptions specifies the query
 	QuerySubscriptions = "subscriptions"
 	//SubscriptionsVarTemplate is the template used to create the graphql query
-	SubscriptionsVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}"{{end}}`
+	SubscriptionsVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}}{{end}}`
 )
 
 //SubscriptionsVariables are the variables used for the subscription query

--- a/client/actions/versions/add_channel_version.go
+++ b/client/actions/versions/add_channel_version.go
@@ -7,7 +7,7 @@ import (
 const (
 	ContentType                  = "application/yaml"
 	QueryAddChannelVersion       = "addChannelVersion"
-	AddChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","channelUuid":"{{json .ChannelUUID}}","name":"{{json .Name}}","type":"{{json .ContentType}}","content":"{{json .Content}}","description":"{{json .Description}}"{{end}}`
+	AddChannelVersionVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"channelUuid":{{json .ChannelUUID}},"name":{{json .Name}},"type":{{json .ContentType}},"content":{{json .Content}},"description":{{json .Description}}{{end}}`
 )
 
 // AddChannelVersionVariables to create addChannelVersion graphql request

--- a/client/actions/versions/add_channel_version.go
+++ b/client/actions/versions/add_channel_version.go
@@ -7,7 +7,7 @@ import (
 const (
 	ContentType                  = "application/yaml"
 	QueryAddChannelVersion       = "addChannelVersion"
-	AddChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","channelUuid":"{{js .ChannelUUID}}","name":"{{js .Name}}","type":"{{js .ContentType}}","content":"{{js .Content}}","description":"{{js .Description}}"{{end}}`
+	AddChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","channelUuid":"{{json .ChannelUUID}}","name":"{{json .Name}}","type":"{{json .ContentType}}","content":"{{json .Content}}","description":"{{json .Description}}"{{end}}`
 )
 
 // AddChannelVersionVariables to create addChannelVersion graphql request

--- a/client/actions/versions/channel_version.go
+++ b/client/actions/versions/channel_version.go
@@ -9,7 +9,7 @@ const (
 	//QueryChannelVersion specifies the query
 	QueryChannelVersion = "channelVersion"
 	// ChannelVersionVarTemplate is the template used to create the graphql query
-	ChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","channelUuid":"{{json .ChannelUUID}}","versionUuid":"{{json .VersionUUID}}"{{end}}`
+	ChannelVersionVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"channelUuid":{{json .ChannelUUID}},"versionUuid":{{json .VersionUUID}}{{end}}`
 )
 
 // ChannelVersionVariables are the variables used for the subscription query

--- a/client/actions/versions/channel_version.go
+++ b/client/actions/versions/channel_version.go
@@ -9,7 +9,7 @@ const (
 	//QueryChannelVersion specifies the query
 	QueryChannelVersion = "channelVersion"
 	// ChannelVersionVarTemplate is the template used to create the graphql query
-	ChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","channelUuid":"{{js .ChannelUUID}}","versionUuid":"{{js .VersionUUID}}"{{end}}`
+	ChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","channelUuid":"{{json .ChannelUUID}}","versionUuid":"{{json .VersionUUID}}"{{end}}`
 )
 
 // ChannelVersionVariables are the variables used for the subscription query

--- a/client/actions/versions/channel_version_by_name.go
+++ b/client/actions/versions/channel_version_by_name.go
@@ -9,7 +9,7 @@ const (
 	//QueryChannelVersionByName specifies the query
 	QueryChannelVersionByName = "channelVersionByName"
 	// ChannelVersionByNameVarTemplate is the template used to create the graphql query
-	ChannelVersionByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","channelName":"{{json .ChannelName}}","versionName":"{{json .VersionName}}"{{end}}`
+	ChannelVersionByNameVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"channelName":{{json .ChannelName}},"versionName":{{json .VersionName}}{{end}}`
 )
 
 //SubscriptionsVariables are the variables used for the subscription query

--- a/client/actions/versions/channel_version_by_name.go
+++ b/client/actions/versions/channel_version_by_name.go
@@ -9,7 +9,7 @@ const (
 	//QueryChannelVersionByName specifies the query
 	QueryChannelVersionByName = "channelVersionByName"
 	// ChannelVersionByNameVarTemplate is the template used to create the graphql query
-	ChannelVersionByNameVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","channelName":"{{js .ChannelName}}","versionName":"{{js .VersionName}}"{{end}}`
+	ChannelVersionByNameVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","channelName":"{{json .ChannelName}}","versionName":"{{json .VersionName}}"{{end}}`
 )
 
 //SubscriptionsVariables are the variables used for the subscription query

--- a/client/actions/versions/remove_channel_version.go
+++ b/client/actions/versions/remove_channel_version.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryRemoveChannelVersion       = "removeChannelVersion"
-	RemoveChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
+	RemoveChannelVersionVarTemplate = `{{define "vars"}}"orgId":{{json .OrgID}},"uuid":{{json .UUID}}{{end}}`
 )
 
 // RemoveChannelVersionVariables are the variables specific to adding a group.

--- a/client/actions/versions/remove_channel_version.go
+++ b/client/actions/versions/remove_channel_version.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	QueryRemoveChannelVersion       = "removeChannelVersion"
-	RemoveChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{js .OrgID}}","uuid":"{{js .UUID}}"{{end}}`
+	RemoveChannelVersionVarTemplate = `{{define "vars"}}"orgId":"{{json .OrgID}}","uuid":"{{json .UUID}}"{{end}}`
 )
 
 // RemoveChannelVersionVariables are the variables specific to adding a group.

--- a/client/auth/local/sign_in.go
+++ b/client/auth/local/sign_in.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	MutationSignIn    = "signIn"
-	SignInVarTemplate = `{{define "vars"}}"login":"{{json .Login}}","password":"{{json .Password}}"{{end}}`
+	SignInVarTemplate = `{{define "vars"}}"login":{{json .Login}},"password":{{json .Password}}{{end}}`
 )
 
 // AddSignInVariables are the variables specific to log in a user.

--- a/client/auth/local/sign_in.go
+++ b/client/auth/local/sign_in.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	MutationSignIn    = "signIn"
-	SignInVarTemplate = `{{define "vars"}}"login":"{{js .Login}}","password":"{{js .Password}}"{{end}}`
+	SignInVarTemplate = `{{define "vars"}}"login":"{{json .Login}}","password":"{{json .Password}}"{{end}}`
 )
 
 // AddSignInVariables are the variables specific to log in a user.

--- a/client/auth/local/sign_up.go
+++ b/client/auth/local/sign_up.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	MutationSignUp    = "signUp"
-	SignUpVarTemplate = `{{define "vars"}}"username":"{{js .Username}}","email":"{{js .Email}}","password":"{{js .Password}}","orgName":"{{js .OrgName}}","role":"{{js .Role}}"{{end}}`
+	SignUpVarTemplate = `{{define "vars"}}"username":"{{json .Username}}","email":"{{json .Email}}","password":"{{json .Password}}","orgName":"{{json .OrgName}}","role":"{{json .Role}}"{{end}}`
 )
 
 // AddSignUpVariables are the variables specific to adding a user.

--- a/client/auth/local/sign_up.go
+++ b/client/auth/local/sign_up.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	MutationSignUp    = "signUp"
-	SignUpVarTemplate = `{{define "vars"}}"username":"{{json .Username}}","email":"{{json .Email}}","password":"{{json .Password}}","orgName":"{{json .OrgName}}","role":"{{json .Role}}"{{end}}`
+	SignUpVarTemplate = `{{define "vars"}}"username":{{json .Username}},"email":{{json .Email}},"password":{{json .Password}},"orgName":{{json .OrgName}},"role":{{json .Role}}{{end}}`
 )
 
 // AddSignUpVariables are the variables specific to adding a user.

--- a/client/web/client_test.go
+++ b/client/web/client_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Client", func() {
 				h.DoReturns(response, nil)
 
 				// Setup the template
-				requestTemplate = `{{define "vars"}}"name":"{{json .Name}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"name":{{json .Name}}{{end}}`
 				vars = QueryVars{
 					Name: "foo",
 				}

--- a/client/web/client_test.go
+++ b/client/web/client_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Client", func() {
 				h.DoReturns(response, nil)
 
 				// Setup the template
-				requestTemplate = `{{define "vars"}}"name":"{{js .Name}}"{{end}}`
+				requestTemplate = `{{define "vars"}}"name":"{{json .Name}}"{{end}}`
 				vars = QueryVars{
 					Name: "foo",
 				}


### PR DESCRIPTION
We build GraphQL queries with Go templates. We were using a built-in
`js` template function for escaping arbitrary strings before using them
as JSON strings. Which _almost_ works; it's not the intended use case
for `js`. We actually needed a custom template function, as implemented
here.

Most of the changes in this commit are essentially replacing `js` with
`json` where templates are defined. The meat of the commit is in
`query.go` and `query_test.go`