### PR TITLE
Remove HTTPClient arg from client.New().

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,7 +31,12 @@ type SatCon struct {
 }
 
 //New creates new SatCon clients
-func New(endpointURL string, httpClient web.HTTPClient, authClient auth.AuthClient) (SatCon, error) {
+func New(endpointURL string, authClient auth.AuthClient) (SatCon, error) {
+	return NewWithCustomHTTPClient(endpointURL, nil, authClient)
+}
+
+//NewWithCustomHTTPClient creates new SatCon clients with a custom web.HTTPClient
+func NewWithCustomHTTPClient(endpointURL string, httpClient web.HTTPClient, authClient auth.AuthClient) (SatCon, error) {
 	var (
 		err error
 		s   SatCon

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Client", func() {
 		})
 
 		It("Creates a new SatCon client", func() {
-			s, err := New(endpointURL, nil, iamClient.Client)
+			s, err := New(endpointURL, iamClient.Client)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(s.Channels).NotTo(BeNil())
 			Expect(s.Clusters).NotTo(BeNil())
@@ -41,7 +41,7 @@ var _ = Describe("Client", func() {
 		})
 
 		It("Errors when endpointURL is empty", func() {
-			s, err := New("", nil, iamClient.Client)
+			s, err := New("", iamClient.Client)
 			Expect(err).To(HaveOccurred())
 			Expect(s.Channels).To(BeNil())
 			Expect(s.Clusters).To(BeNil())

--- a/client/web/client.go
+++ b/client/web/client.go
@@ -3,7 +3,6 @@ package web
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -96,9 +95,9 @@ func CheckResponseForErrors(body []byte) error {
 			var errorMessage string
 			errLength := len(errorDetails.Errors)
 			for i := range errorDetails.Errors {
-				errorMessage += fmt.Sprintf("%s", errorDetails.Errors[i].Message)
+				errorMessage += errorDetails.Errors[i].Message
 				if i < (errLength - 1) {
-					errorMessage += fmt.Sprint(", ")
+					errorMessage += ", "
 				}
 			}
 			return errors.New(errorMessage)

--- a/client/web/client_test.go
+++ b/client/web/client_test.go
@@ -93,7 +93,8 @@ var _ = Describe("Client", func() {
 			})
 
 			It("Deserializes the response body into the result", func() {
-				s.DoQuery(requestTemplate, vars, nil, &result)
+				err := s.DoQuery(requestTemplate, vars, nil, &result)
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Name).To(Equal(name))
 			})
 
@@ -136,7 +137,7 @@ var _ = Describe("Client", func() {
 				})
 			})
 
-			Context("When unmarshalling errors", func() {
+			Context("When unmarshaling errors", func() {
 				It("Bubbles up the unmarshal error", func() {
 					err := s.DoQuery(requestTemplate, vars, nil, nil)
 					_, ok := err.(*json.InvalidUnmarshalError)
@@ -167,7 +168,7 @@ var _ = Describe("Client", func() {
 					}
 
 					response = &http.Response{
-						Body: ioutil.NopCloser(bytes.NewBufferString(fmt.Sprint(`{"errors": [{"message": "Context creation failed: Your session expired. Sign in again","extensions": {"code": "UNAUTHENTICATED"}}]}`))),
+						Body: ioutil.NopCloser(bytes.NewBufferString(`{"errors": [{"message": "Context creation failed: Your session expired. Sign in again","extensions": {"code": "UNAUTHENTICATED"}}]}`)),
 					}
 
 					h.DoReturns(response, nil)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/IBM/go-sdk-core/v4 v4.8.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0
 	github.com/onsi/ginkgo v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
+github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=

--- a/test/integration/channels_test.go
+++ b/test/integration/channels_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Channels", func() {
 		var iamClient *iam.Client
 		iamClient, err = iam.NewIAMClient(testConfig.APIKey, testConfig.IAMEndpoint)
 		Expect(err).ToNot(HaveOccurred())
-		c, _ = client.New(testConfig.SatConEndpoint, nil, iamClient.Client)
+		c, _ = client.New(testConfig.SatConEndpoint, iamClient.Client)
 		Expect(c.Channels).NotTo(BeNil())
 	})
 

--- a/test/integration/clusters_test.go
+++ b/test/integration/clusters_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Clusters", func() {
 		var err error
 		iamClient, err = iam.NewIAMClient(testConfig.APIKey, testConfig.IAMEndpoint)
 		Expect(err).ToNot(HaveOccurred())
-		c, _ = client.New(testConfig.SatConEndpoint, nil, iamClient.Client)
+		c, _ = client.New(testConfig.SatConEndpoint, iamClient.Client)
 		Expect(c.Clusters).NotTo(BeNil())
 	})
 

--- a/test/integration/groups_test.go
+++ b/test/integration/groups_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Groups", func() {
 		var err error
 		iamClient, err = iam.NewIAMClient(testConfig.APIKey, testConfig.IAMEndpoint)
 		Expect(err).ToNot(HaveOccurred())
-		c, _ = client.New(testConfig.SatConEndpoint, nil, iamClient.Client)
+		c, _ = client.New(testConfig.SatConEndpoint, iamClient.Client)
 		Expect(c.Groups).NotTo(BeNil())
 	})
 

--- a/test/integration/subscriptions_test.go
+++ b/test/integration/subscriptions_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Subscriptions", func() {
 		var err error
 		iamClient, err = iam.NewIAMClient(testConfig.APIKey, testConfig.IAMEndpoint)
 		Expect(err).ToNot(HaveOccurred())
-		c, _ = client.New(testConfig.SatConEndpoint, nil, iamClient.Client)
+		c, _ = client.New(testConfig.SatConEndpoint, iamClient.Client)
 		Expect(c.Subscriptions).NotTo(BeNil())
 
 		encodedContent := "YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IGludGVncmF0aW9uX3Rlc3QKc3BlYzoKICBjb250YWluZXJzOgogIC0gbmFtZTogaW50ZWdyYXRpb25fdGVzdAogICAgaW1hZ2U6IGh0dHBkOmFscGluZQo="

--- a/test/integration/users_test.go
+++ b/test/integration/users_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Users", func() {
 		var err error
 		iamClient, err = iam.NewIAMClient(testConfig.APIKey, testConfig.IAMEndpoint)
 		Expect(err).ToNot(HaveOccurred())
-		c, _ = client.New(testConfig.SatConEndpoint, nil, iamClient.Client)
+		c, _ = client.New(testConfig.SatConEndpoint, iamClient.Client)
 		Expect(c.Clusters).NotTo(BeNil())
 	})
 

--- a/test/integration/versions_test.go
+++ b/test/integration/versions_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Versions", func() {
 		var err error
 		iamClient, err = iam.NewIAMClient(testConfig.APIKey, testConfig.IAMEndpoint)
 		Expect(err).ToNot(HaveOccurred())
-		c, _ = client.New(testConfig.SatConEndpoint, nil, iamClient.Client)
+		c, _ = client.New(testConfig.SatConEndpoint, iamClient.Client)
 		Expect(c.Versions).NotTo(BeNil())
 
 		encodedContent := "YXBpVmVyc2lvbjogdjEKa2luZDogUG9kCm1ldGFkYXRhOgogIG5hbWU6IGludGVncmF0aW9uX3Rlc3QKc3BlYzoKICBjb250YWluZXJzOgogIC0gbmFtZTogaW50ZWdyYXRpb25fdGVzdAogICAgaW1hZ2U6IGh0dHBkOmFscGluZQo="
@@ -48,7 +48,7 @@ var _ = Describe("Versions", func() {
 		})
 
 		It("Gets our channel version by name to show it does not exist, creates a channel, creates a "+
-			"channel version, gets the versionby name, removes the version, removes the channel, then tries "+
+			"channel version, gets the version by name, removes the version, removes the channel, then tries "+
 			"to get the version by name again to show it no longer exists", func() {
 			// Demonstrate channel version does not exist for the arguments of the current channelName and versionName
 			version, err := c.Versions.ChannelVersionByName(testConfig.OrgID, channelName, versionName)


### PR DESCRIPTION
Previously one was always required to provide a web.HTTPClient, which
everyone always just sets to `nil`. If you really want to provide one
use `NewWithCustomHTTPClient()`.

In passing fix some typos and lint errors.